### PR TITLE
use nomodule when defining fallback scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,7 @@ module.exports = class Client {
                 new AssetJs({
                     ...jsOptions,
                     type: 'iife',
+                    nomodule: true,
                     value:
                         server +
                         join(

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -162,6 +162,7 @@ test('development mode false', t => {
                 type: 'iife',
                 value:
                     'http://localhost:4001/my-org/pkg/my-app-name/1.0.0/ie11/index.js',
+                nomodule: true,
             },
         ],
         'client.js should return JS assets object',
@@ -203,6 +204,7 @@ test('development mode false, setting options', t => {
                 async: true,
                 defer: true,
                 type: 'iife',
+                nomodule: true,
             },
         ],
         'client.js should return JS assets object',
@@ -232,7 +234,7 @@ test('development mode false, scripts and styles', t => {
     t.same(
         JSON.parse(JSON.stringify(c.scripts)),
         `<script src="http://localhost:4001/my-org/pkg/my-app-name/1.0.0/main/index.js" type="module"></script>
-<script src="http://localhost:4001/my-org/pkg/my-app-name/1.0.0/ie11/index.js"></script>`,
+<script src="http://localhost:4001/my-org/pkg/my-app-name/1.0.0/ie11/index.js" nomodule></script>`,
         'client.scripts should return JS scripts markup',
     );
     t.same(


### PR DESCRIPTION
Set `nomodule` on fallback scripts